### PR TITLE
Version bump of docker containers to latest releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# vscode
+/.ralph-lsp/

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
 
   explorer-backend:
     container_name: alephium_explorer_backend
-    image: alephium/explorer-backend:v1.19.4
+    image: alephium/explorer-backend:v2.2.1
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   alephium:
-    image: alephium/alephium:v2.3.5
+    image: alephium/alephium:v3.6.0
     restart: "no"
     ports:
       - 19973:19973/tcp
@@ -52,7 +52,7 @@ services:
 
   explorer-backend:
     container_name: alephium_explorer_backend
-    image: alephium/explorer-backend:v1.13.4
+    image: alephium/explorer-backend:v1.19.4
     depends_on:
       postgres:
         condition: service_healthy
@@ -79,7 +79,7 @@ services:
 
   explorer-frontend:
     container_name: alephium_explorer_frontend
-    image: alephium/explorer:1.6.5
+    image: alephium/explorer:1.10.4
     depends_on:
       - explorer-backend
     restart: "no"


### PR DESCRIPTION
I went through the `first-dapp-with-nextjs` tutorial compiling the contracts throws : 
```
✘ Failed to compile, error: Connected full node version is 2.3.5, the minimum required version is 3.6.0
```
As there is still node version 2.3.5.

I finished whole `first-dapp-with-nextjs` with this deployment fine.